### PR TITLE
Delete disp-formula tags from caption.

### DIFF
--- a/xquery/elife2dar.xq
+++ b/xquery/elife2dar.xq
@@ -62,7 +62,9 @@ return (insert node attribute mime-subtype {$ms} into $x,
   return delete node $f,
   
   for $x in  $copy//*:p//*:disp-formula
-  return (insert node $x after $x/ancestor::*:p[1],
+  return 
+  if ($x/ancestor::caption) then delete node $x
+  else (insert node $x after $x/ancestor::*:p[1],
           delete node $x),
   
   for $o in $copy//*:abstract[@abstract-type="executive-summary"]


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-jats-2-dar-jats/issues/10

I did this to get more validation passes by deleting `<disp-formula>` tags if they're inside `<caption>`, otherwise it follows the logic you had @FAtherden-eLife for adding after a `<p>` tag.