### PR TITLE
Add an id attribute to td tags.

### DIFF
--- a/xquery/elife2dar.xq
+++ b/xquery/elife2dar.xq
@@ -239,8 +239,12 @@ modify(
   else if ($x/@ext-link-type) then
     if ($x/@ext-link-type='uri') then ()
     else replace value of node $x/@ext-link-type with 'uri'
-  else insert node attribute ext-link {'uri'} into $x
-  
+  else insert node attribute ext-link {'uri'} into $x,
+
+  for $x at $position in $copy5//td[not(@id)]
+    let $td_id := concat('t_', $position)
+    return insert node attribute id {$td_id} into $x
+
 )
 return $copy5
 return file:write($outputDir,$y)


### PR DESCRIPTION
Very simple example of adding unique `id` attributes to `<td>` tags, fixes some validation and display of inline tagging in tables. This may not be ideal or what you might come up with @FAtherden-eLife but is an attempt of mine that seems to be producing a valid result.