### PR TITLE
PoA have no body tag to receive content.

### DIFF
--- a/xquery/elife2dar.xq
+++ b/xquery/elife2dar.xq
@@ -110,8 +110,8 @@ for $x in $copy2//*:addr-line[*:named-content]
 return replace node $x with <city>{$x/(*:named-content/*|*:named-content/text())}</city>,
 
 for $x in $copy2//*:back/*:sec
-  return if ($x/@sec-type="additional-information") then (insert node $x as last into $x/preceding::*:body, delete node $x)
-  else if ($x/@sec-type="supplementary-material") then (insert node $x as last into $x/preceding::*:body, delete node $x)
+  return if ($x/@sec-type="additional-information" and $x/preceding::*:body) then (insert node $x as last into $x/preceding::*:body, delete node $x)
+  else if ($x/@sec-type="supplementary-material" and $x/preceding::*:body) then (insert node $x as last into $x/preceding::*:body, delete node $x)
   else delete node $x,
    
   for $x in  $copy2//*:underline/*:named-content[@content-type="sequence"]


### PR DESCRIPTION
If the XQuery can check whether a `<body>` tag is present before adding content to it, this would alleviate errors in converting and validating PoA XML articles.

I tried adding a `<body>` tag first if it is not present, but then after the `<sec>` tags from a PoA article are added to the new `<body>`, the result triggers Texture validation warnings, and also some of the content is added. I think PoA articles can probably be ignored for additional testing with Texture so it is safe to just throw away the content in the `<back>` of them.